### PR TITLE
Fix attribute persistence

### DIFF
--- a/lib/jekyll-picture-tag/instructions/html_attributes.rb
+++ b/lib/jekyll-picture-tag/instructions/html_attributes.rb
@@ -19,7 +19,7 @@ module PictureTag
       private
 
       def load_preset
-        PictureTag.preset['attributes'] || {}
+        PictureTag.preset['attributes'].dup || {}
       end
 
       # Syntax this function processes:


### PR DESCRIPTION
Attribute processing was inserting new attributes into jekyll's
attributes hash, persisting them between tags. This change 
duplicates the hash and modifies that copy, rather than the 
original.

fix #123 